### PR TITLE
Update TypeScript definition for ES6 import compatibility

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,5 +21,6 @@ declare module "uniqolor" {
   }
 
   const uniqolor: Uniqolor;
-  export = uniqolor;
+  export function random(options?: RandomOptions): Color;
+  export default uniqolor;
 }


### PR DESCRIPTION
This PR updates the `index.d.ts` TypeScript definition file to support ES6 import syntax without requiring the `allowSyntheticDefaultImports` compiler option. The change aligns the TypeScript definitions with the ES6 module standard, making it easier to import `Uniqolor` in TypeScript projects that use ES6 modules.

- Removed `export = uniqolor;`
- Added `export default uniqolor;`
- Added a named export for the `random` method

This update should be backward compatible with existing usages and improve support for modern TypeScript projects.

This will now work without typescript warning:
`import uniqolor from 'uniqolor'`